### PR TITLE
Don't force the use of SSLv3

### DIFF
--- a/src/common/ssl.c
+++ b/src/common/ssl.c
@@ -70,7 +70,7 @@ _SSL_context_init (void (*info_cb_func), int server)
 
 	SSLeay_add_ssl_algorithms ();
 	SSL_load_error_strings ();
-	ctx = SSL_CTX_new (server ? SSLv3_server_method() : SSLv3_client_method ());
+	ctx = SSL_CTX_new (server ? SSLv23_server_method() : SSLv23_client_method ());
 
 	SSL_CTX_set_session_cache_mode (ctx, SSL_SESS_CACHE_BOTH);
 	SSL_CTX_set_timeout (ctx, 300);
@@ -281,7 +281,7 @@ _SSL_socket (SSL_CTX *ctx, int sd)
 		__SSL_critical_error ("SSL_new");
 
 	SSL_set_fd (ssl, sd);
-	if (ctx->method == SSLv3_client_method())
+	if (ctx->method == SSLv23_client_method())
 		SSL_set_connect_state (ssl);
 	else
 	        SSL_set_accept_state(ssl);


### PR DESCRIPTION
This PR applies a patch to the xchat core that was also applied to the xchat-gnome package, see [bug 1381484](https://bugs.launchpad.net/ubuntu/+source/xchat-gnome/+bug/1381484).

This should fix [issue 152](https://github.com/xchataqua/xchataqua/issues/152) in xchat aqua.
