### PR TITLE
Fixes for inconsistent SSL behavior

### DIFF
--- a/src/common/server.c
+++ b/src/common/server.c
@@ -851,14 +851,16 @@ server_connect_success (server *serv)
 
 		/* it'll be a memory leak, if connection isn't terminated by
 		   server_cleanup() */
-		serv->ssl = _SSL_socket (ctx, serv->sok);
-		if ((err = _SSL_set_verify (ctx, NULL, NULL)))
+		if ((err = _SSL_set_verify (ctx, NULL)))
 		{
 			EMIT_SIGNAL (XP_TE_CONNFAIL, serv->server_session, err, NULL,
 							 NULL, NULL, 0);
 			server_cleanup (serv);	/* ->connecting = FALSE */
 			return;
 		}
+		
+		serv->ssl = _SSL_socket (ctx, serv->sok);
+
 		/* FIXME: it'll be needed by new servers */
 		/* send(serv->sok, "STLS\r\n", 6, 0); sleep(1); */
 		set_nonblocking (serv->sok);

--- a/src/common/ssl.c
+++ b/src/common/ssl.c
@@ -291,7 +291,7 @@ _SSL_socket (SSL_CTX *ctx, int sd)
 
 
 char *
-_SSL_set_verify (SSL_CTX *ctx, void *verify_callback, char *cacert)
+_SSL_set_verify (SSL_CTX *ctx, char *cacert)
 {
 	if (!SSL_CTX_set_default_verify_paths (ctx))
 	{
@@ -308,7 +308,8 @@ _SSL_set_verify (SSL_CTX *ctx, void *verify_callback, char *cacert)
 		}
 	}
 */
-	SSL_CTX_set_verify (ctx, SSL_VERIFY_PEER, (int (*)(int, X509_STORE_CTX *))verify_callback);
+
+	SSL_CTX_set_verify (ctx, SSL_VERIFY_NONE, NULL);
 
 	return (NULL);
 }

--- a/src/common/ssl.h
+++ b/src/common/ssl.h
@@ -27,7 +27,7 @@ SSL_CTX *_SSL_context_init (void *info_cb_func, int server);
 #define _SSL_context_free(a)	SSL_CTX_free(a);
 
 SSL *_SSL_socket (SSL_CTX *ctx, int sd);
-char *_SSL_set_verify (SSL_CTX *ctx, void *verify_callback, char *cacert);
+char *_SSL_set_verify (SSL_CTX *ctx, char *cacert);
 /*
     int SSL_connect(SSL *);
     int SSL_accept(SSL *);


### PR DESCRIPTION
Call _SSL_set_verify before calling SSL_new. _SSL_set_verify operates on
the context so the changes only apply to sockets created after this
call.

Removed callback parameter from _SSL_set_verify and change
_SSL_set_verify to use SSL_VERIFY_NONE instead of
SSL_VERIFY_PEER, we check the certs manually later on.
#203, #86, #170
