### PR TITLE
force usage of TLSv1 or better.

### DIFF
--- a/src/common/ssl.c
+++ b/src/common/ssl.c
@@ -70,7 +70,9 @@ _SSL_context_init (void (*info_cb_func), int server)
 
 	SSLeay_add_ssl_algorithms ();
 	SSL_load_error_strings ();
-	ctx = SSL_CTX_new (server ? SSLv23_server_method() : SSLv23_client_method ());
+	ctx = SSL_CTX_new (server ? TLSv1_server_method() : TLSv1_client_method ());
+	SSL_CTX_set_options(ctx, SSL_OP_NO_SSLv2);
+	SSL_CTX_set_options(ctx, SSL_OP_NO_SSLv3);
 
 	SSL_CTX_set_session_cache_mode (ctx, SSL_SESS_CACHE_BOTH);
 	SSL_CTX_set_timeout (ctx, 300);


### PR DESCRIPTION
It was a really bad idea to allow fall back even to SSLv2! This fixes it and also mitigates the POODLE attack problem of SSLv3.
